### PR TITLE
Include the license file in sdists and wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE.txt
+include requirements.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [metadata]
 description-file = README.md
+license_file =  LICENSE.txt


### PR DESCRIPTION
The terms of the MIT license requires all copies of the program include the license text.