### PR TITLE
Update signal.py

### DIFF
--- a/soundsig/signal.py
+++ b/soundsig/signal.py
@@ -5,7 +5,8 @@ import mne
 import pandas as pd
 from scipy.fftpack import fft,fftfreq,ifft,fftshift
 from scipy.ndimage import convolve1d
-from scipy.signal import filter_design, resample, filtfilt, hann 
+from scipy.signal import filter_design, resample, filtfilt
+from scipy.signal.windows import hann
 import matplotlib.pyplot as plt
 import nitime.algorithms as ntalg
 from sklearn.decomposition import PCA

--- a/soundsig/sound.py
+++ b/soundsig/sound.py
@@ -365,7 +365,7 @@ class BioSound(object):
         if np.size(goodFund) == 0 or np.size(goodFund2) == 0:
             fund2prop = 0.0
         else:
-            fund2prop = np.float(np.size(goodFund2))/np.float(np.size(goodFund))
+            fund2prop = np.float64(np.size(goodFund2))/np.float64(np.size(goodFund))
             
         self.f0 = fund         # time varying fundamental
         self.f0_2 = fund2        # time varying fundamental of second voice


### PR DESCRIPTION
Change `from scipy.signal import hann` to `from scipy.signal.windows import hann` as the Hann window has now been shifted to the `signal.windows` module in the latest release of SciPy.

Change calls to `numpy.float()` to `numpy.float64()` as the former has been deprecated.

